### PR TITLE
Persist client pairing/unpairing, and some cleanup

### DIFF
--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -16,7 +16,11 @@ class BluetoothServer: # pylint: disable=C1001,R0903,R0902
     BluetoothServer
     Advertises bluetooth services, handles connection and clients
     """
-    def __init__(self, bluetooth_ids={}, client_ids=set()): # pylint: disable=W0102
+    def __init__(self, # pylint: disable=W0102
+                 bluetooth_ids={},
+                 client_ids=set(),
+                 on_client_paired=None,
+                 on_client_unpaired=None):
         # Read bluetooth IDs:
         self.__bt_id = bluetooth_ids.get('bt_id')
         self.__bt_pair_svc_id = bluetooth_ids.get('bt_pair_svc_id')
@@ -24,6 +28,8 @@ class BluetoothServer: # pylint: disable=C1001,R0903,R0902
         self.__bt_pair_add_char_id = bluetooth_ids.get('bt_pair_add_char_id')
         self.__bt_pair_remove_char_id = bluetooth_ids.get('bt_pair_remove_char_id')
         self.__bt_sync_data_char_id = bluetooth_ids.get('bt_sync_data_char_id')
+        self.__on_client_paired = on_client_paired
+        self.__on_client_unpaired = on_client_unpaired
         # Save currently paired clients
         self.client_ids = client_ids
         # Setup bluetooth & configure advertisement.
@@ -68,6 +74,13 @@ class BluetoothServer: # pylint: disable=C1001,R0903,R0902
         # Start advertising:
         self.bluetooth.advertise(True)
 
+    def update_client_ids(self, client_ids):
+        """
+        set_client_ids
+        Update the client_ids
+        """
+        self.client_ids = client_ids
+
     def __on_connection_status_changed(self, bt_o):
         events = bt_o.events()
         if events & Bluetooth.CLIENT_CONNECTED:
@@ -76,16 +89,27 @@ class BluetoothServer: # pylint: disable=C1001,R0903,R0902
             self.__on_client_disconnected(bt_o)
 
     def __on_client_connected(self, bt_o): # pylint: disable=R0201
-        print('Client connected: ', bt_o.get_adv(), bt_o.uuid)
+        adv = bt_o.get_adv()
+        print('Client connected: ', adv)
 
     def __on_client_disconnected(self, bt_o): # pylint: disable=R0201
-        print('Client disconnected: ', bt_o.get_adv(), bt_o.uuid)
+        adv = bt_o.get_adv()
+        print('Client disconnected: ', adv)
 
-    def __on_pair_add(self, data): # pylint: disable=R0201
-        print("pair_add: ", data)
+    def __on_pair_add(self, ch): # pylint: disable=R0201,C0103
+        """
+        __on_pair_add
+        Triggered from the pair-add characteristic.
+        Expected data is the unique "client id" from the app.
+        """
+        client_id = ch.value().decode()
+        self.__on_client_paired(client_id)
+        print("pair_add: ", client_id)
 
-    def __on_pair_remove(self, data): # pylint: disable=R0201
-        print("pair_remove: ", data)
+    def __on_pair_remove(self, ch): # pylint: disable=R0201,C0103
+        client_id = ch.value().decode()
+        self.__on_client_unpaired(client_id)
+        print("pair_remove: ", client_id)
 
-    def __on_sync_data(self, data): # pylint: disable=R0201
-        print("sync_data: ", data)
+    def __on_sync_data(self, ch): # pylint: disable=R0201,C0103
+        print("sync_data: ", ch)

--- a/src/device.py
+++ b/src/device.py
@@ -1,50 +1,16 @@
 """
 device.py
 
-Device object;
-- handles reading/writing of the device info file.
-- handles setting up of sensor object
-- handles recording of event objects into cache
+Contains the Device class. Used for interacting with device & managing data.
 """
 from lib.dht import DHT
 from lib.lru_cache import LRUCache, calculate_cache_size
 import src.event as event
-from src.device_info import DeviceInfo
-from src.device_info import generate_device_info_file, write_device_info_file, reset_device_info
+from src.device_info import generate_device_info_file, write_device_info_file
+from src.device_info import reset_device_info, read_device_info_file, does_device_info_file_exist
 from src.bluetooth import BluetoothServer
 # MicroPython libraries:
-import ujson # pylint: disable=F0401
-import uio   # pylint: disable=F0401
 from machine import Pin # pylint: disable=F0401
-
-# Path to json file where device info is stored
-DEVICE_INFO_PATH = '/flash/device-info.json'
-
-def create_device_info_file():
-    """
-    create_device_info_file
-    Creates the device info json file with a fresh deviceID
-    """
-    try:
-        with uio.open(DEVICE_INFO_PATH, mode='w') as outfile:
-            info = DeviceInfo(generate_initial_values=True)
-            outfile.write(info.to_json())
-        outfile.close()
-    except OSError as err:
-        print("Could not create device info file: ", err)
-
-def does_file_exist(filename):
-    """
-    does_file_exist
-    Returns true if the given filename exists, false otherwise.
-    """
-    exists = False
-    try:
-        with uio.open(filename, mode='r'):
-            exists = True
-    except OSError:
-        pass
-    return exists
 
 class Device: # pylint: disable=C1001
     """
@@ -59,15 +25,17 @@ class Device: # pylint: disable=C1001
         self.dht_sensor = DHT(Pin('P11', mode=Pin.OPEN_DRAIN), 1)
         self.events = LRUCache(calculate_cache_size(duration, interval))
         self.bluetooth_server = BluetoothServer(
-            self.device_info.get_bluetooth_ids(),
-            self.device_info.client_ids)
+            bluetooth_ids=self.device_info.get_bluetooth_ids(),
+            client_ids=self.device_info.client_ids,
+            on_client_paired=self.__on_client_paired,
+            on_client_unpaired=self.__on_client_unpaired)
 
     def init_device_info(self):
         """
         init_device_info
         Reads device info if it exists.  Creates a new device info file otherwise.
         """
-        if not does_file_exist(DEVICE_INFO_PATH):
+        if not does_device_info_file_exist():
             generate_device_info_file()
 
         self.read_device_info()
@@ -75,15 +43,10 @@ class Device: # pylint: disable=C1001
     def read_device_info(self):
         """
         read_device_info
-        Reads the device info JSON file, parses it, and assigns data to device object
+        Reads the device device info from file, and assigns the object to this class.
         """
-        try:
-            with uio.open(DEVICE_INFO_PATH, mode='r') as infile:
-                device_data = ujson.loads(infile.read())
-                self.device_info = DeviceInfo(device_data)
-            infile.close()
-        except OSError as err:
-            print("Could not open ", DEVICE_INFO_PATH, err)
+        device_info = read_device_info_file()
+        self.device_info = device_info
 
     def update_device_info(self):
         """
@@ -113,3 +76,25 @@ class Device: # pylint: disable=C1001
             new_event.log() # log event data to console
         else:
             print('Invalid sensor data.', dht_result)
+
+    def __on_client_paired(self, client_id):
+        """
+        __on_client_paired
+        Triggered by BluetoothServer when a new client has paired.
+        """
+        if not client_id in self.device_info.client_ids:
+            self.device_info.client_ids.add(client_id)
+            self.update_device_info()
+            self.bluetooth_server.update_client_ids(self.device_info.client_ids)
+            print('ON PAIR CLIENT! ', self.device_info.client_ids)
+
+    def __on_client_unpaired(self, client_id):
+        """
+        __on_client_unpaired
+        Triggered by BluetoothServer when a device has unpaired.
+        """
+        if client_id in self.device_info.client_ids:
+            self.device_info.client_ids.discard(client_id)
+            self.update_device_info()
+            self.bluetooth_server.update_client_ids(self.device_info.client_ids)
+            print('ON UNPAIR CLIENT! ', self.device_info.client_ids)

--- a/src/device_info.py
+++ b/src/device_info.py
@@ -13,7 +13,6 @@ import uio # pylint: disable=F0401
 DEVICE_INFO_PATH = '/flash/device-info.json'
 
 # pylint: disable=C0325
-
 class DeviceInfo: # pylint: disable=C1001,R0902
     """
     DeviceInfo
@@ -80,6 +79,7 @@ class DeviceInfo: # pylint: disable=C1001,R0902
             "bt_sync_data_char_id": self.bt_sync_data_char_id
             })
 
+# Functions:
 
 def write_device_info_file(device_info):
     """
@@ -102,7 +102,8 @@ def generate_device_info_file():
     generate_device_info_file
     Creates a new device_info_file
     """
-    write_device_info_file(DeviceInfo(generate_initial_values=True))
+    new_device_info = DeviceInfo(generate_initial_values=True)
+    write_device_info_file(new_device_info)
 
 def reset_device_info():
     """
@@ -111,3 +112,42 @@ def reset_device_info():
     """
     os.remove(DEVICE_INFO_PATH)
     generate_device_info_file()
+
+def read_device_info_file():
+    """
+    read_device_info_file
+    Reads device info from disk. Returns a DeviceInfo object.
+    """
+    device_info = None
+    try:
+        with uio.open(DEVICE_INFO_PATH, mode='r') as infile:
+            device_data = ujson.loads(infile.read())
+            device_info = DeviceInfo(device_data)
+        infile.close()
+    except ValueError as err:
+        print("Could not parse device info file JSON", err)
+    except OSError as err:
+        print("Could not open device info file.", err)
+
+    return device_info
+
+def does_device_info_file_exist():
+    """
+    does_device_info_file_exist
+    returns true if device info file exists, false otherwise.
+    """
+    return does_file_exist(DEVICE_INFO_PATH)
+
+def does_file_exist(filename):
+    """
+    does_file_exist
+    Returns true if the given filename exists, false otherwise.
+    """
+    exists = False
+    try:
+        with uio.open(filename, mode='r') as infofile:
+            exists = True
+        infofile.close()
+    except OSError:
+        pass
+    return exists


### PR DESCRIPTION
- Now persisting the client-id when a new device pairs or unpairs over bluetooth
- Did some general refactoring and code cleanup in device & device-info classes.
- Fixed a few random pylint warnings.